### PR TITLE
 ZPI-1-ZPI-86-FE-46, Dodanie sortowania po rating score i innych polach

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -101,6 +101,15 @@
     "noCaretakerProfile": "Currently you do not have caretaker profile"
   },
 
+  "sort": {
+    "title": "Sort",
+    "default": "By default",
+    "avgRatingDesc": "By average rating descending",
+    "avgRatingAsc": "By average rating ascending",
+    "numberOfRatingsDesc": "By number of ratings descending",
+    "numberOfRatingsAsc": "By number of ratings ascending"
+  },
+
   "caretakerSearch": {
     "personalData": "Personal data",
     "animalTypes": "Animal types",
@@ -108,9 +117,6 @@
     "minPrice": "Min price",
     "maxPrice": "Max price",
     "noCaretakers": "There are no caretakers for selected filters",
-    "triggerDesc": "Click to sort descending",
-    "triggerAsc": "Click to sort ascending",
-    "cancelSort": "Click to cancel sorting",
     "list": "Caretaker list",
     "map": "Caretaker map"
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -106,9 +106,14 @@
     "noCaretakerProfile": "Nie posiadasz jeszcze profilu opiekuna"
   },
 
-  "triggerDesc": "Naciśnij aby sortowac malejąco",
-  "triggerAsc": "Naciśnij aby sortowac rosnąco",
-  "cancelSort": "Naciśnij aby anulowac sortowanie",
+  "sort": {
+    "title": "Sortuj",
+    "default": "Domyślnie",
+    "avgRatingDesc": "Po sredniej ocenie malejąco",
+    "avgRatingAsc": "Po sredniej ocenie rosnąco",
+    "numberOfRatingsDesc": "Po liczbie ocen malejąco",
+    "numberOfRatingsAsc": "Po liczbie ocen rosnąco"
+  },
 
   "caretakerSearch": {
     "personalData": "Dane personalne",

--- a/src/components/CaretakerFilters.tsx
+++ b/src/components/CaretakerFilters.tsx
@@ -12,6 +12,7 @@ interface CaretakerFiltersProps {
   onFiltersChange: (filters: CaretakerSearchFilters) => void;
   onAnimalFiltersChange: (animalType: string, updatedConfig: Partial<OfferConfiguration>) => void;
   onAnimalTypesChange: (selectedAnimalTypes: string[]) => void;
+  onSortChange: (sortBy: string, sortDirection: string) => void;
   onSearch: () => void;
 }
 
@@ -21,6 +22,7 @@ const CaretakerFilters: React.FC<CaretakerFiltersProps> = ({
   onFiltersChange,
   onAnimalFiltersChange,
   onAnimalTypesChange,
+  onSortChange,
   onSearch,
 }) => {
   const { t } = useTranslation();
@@ -57,6 +59,34 @@ const CaretakerFilters: React.FC<CaretakerFiltersProps> = ({
     checkAndSwapPrices();
     onSearch();
   };
+
+  const handleSortChange = (sorter: string) => {
+    switch (sorter) {
+      case "default":
+        onSortChange("ratingScore", "DESC");
+        break;
+      case "avgRatingDesc":
+        onSortChange("avgRating", "DESC");
+        break;
+      case "avgRatingAsc":
+        onSortChange("avgRating", "ASC");
+        break;
+      case "numberOfRatingsDesc":
+        onSortChange("numberOfRatings", "DESC");
+        break;
+      case "numberOfRatingsAsc":
+        onSortChange("numberOfRatings", "ASC");
+        break;
+    }
+  };
+
+  const renderAvailableSorters = () => [
+    { value : "default", label: t("sort.default") },
+    { value: "avgRatingDesc", label: t("sort.avgRatingDesc") },
+    { value: "avgRatingAsc", label: t("sort.avgRatingAsc") },
+    { value: "numberOfRatingsDesc", label: t("sort.numberOfRatingsDesc") },
+    { value: "numberOfRatingsAsc", label: t("sort.numberOfRatingsAsc") },
+  ]
 
   const renderAnimalFilters = () =>
     filters.animals?.map(({ animalType }) => (
@@ -121,6 +151,14 @@ const CaretakerFilters: React.FC<CaretakerFiltersProps> = ({
 
   return (
     <div className="caretaker-sidebar">
+      <h2>{t("sort.title")}</h2>
+      <Select
+        style={{ width: "100%" }}
+        showSearch={false}
+        defaultValue="default"
+        options={renderAvailableSorters()}
+        onChange={handleSortChange}
+      />
       <h2>{t("filters")}</h2>
       <div className="filters">
         <Input

--- a/src/pages/CaretakerSearch.tsx
+++ b/src/pages/CaretakerSearch.tsx
@@ -1,12 +1,7 @@
 import { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Table, Button, Rate, Tabs } from "antd";
-import {
-  SorterResult,
-  TablePaginationConfig,
-  FilterValue,
-  ColumnsType,
-} from "antd/es/table/interface";
+import { TablePaginationConfig, ColumnsType } from "antd/es/table/interface";
 import { api } from "../api/api";
 import { useTranslation } from "react-i18next";
 import { CaretakerBasics } from "../models/Caretaker";
@@ -108,27 +103,12 @@ const CaretakerList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pagingParams]);
 
-  const mapSortDirection = (sorter: SorterResult<CaretakerBasics>) => {
-    if (sorter.order) {
-      return sorter.order === "ascend" ? "ASC" : "DESC";
-    } else {
-      return undefined;
-    }
-  };
-
-  const handleTableChange = (
-    pagination: TablePaginationConfig,
-    _filters: Record<string, FilterValue | null>,
-    sorter: SorterResult<CaretakerBasics> | SorterResult<CaretakerBasics>[]
-  ) => {
-    const singleSorter = Array.isArray(sorter) ? sorter[0] : sorter;
-    const isSorted = !!singleSorter.order;
+  const handleTableChange = (pagination: TablePaginationConfig) => {
 
     setPagingParams({
+      ...pagingParams,
       page: (pagination.current || 1) - 1,
-      size: pagination.pageSize || 10,
-      sortBy: isSorted ? ("ratingScore") : undefined,
-      sortDirection: mapSortDirection(singleSorter),
+      size: pagination.pageSize || 10
     });
   };
 

--- a/src/pages/CaretakerSearch.tsx
+++ b/src/pages/CaretakerSearch.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Table, Button, Spin, Rate, Tabs } from "antd";
+import { Table, Button, Rate, Tabs } from "antd";
 import {
   SorterResult,
   TablePaginationConfig,
@@ -17,7 +17,6 @@ import {
 } from "../types";
 import CaretakerFilters from "../components/CaretakerFilters";
 import store from "../store/RootStore";
-import { UserOutlined } from "@ant-design/icons";
 import { toast } from "react-toastify";
 import MapWithCaretakers from "../components/MapWithCaretakers";
 import TabPane from "antd/es/tabs/TabPane";
@@ -34,8 +33,8 @@ const CaretakerList = () => {
   const [pagingParams, setPagingParams] = useState({
     page: 0,
     size: 10,
-    sortBy: undefined as string | undefined,
-    sortDirection: undefined as string | undefined,
+    sortBy: "ratingScore" as string | undefined,
+    sortDirection: "DESC" as string | undefined,
   });
 
   const [pagination, setPagination] = useState({
@@ -128,7 +127,7 @@ const CaretakerList = () => {
     setPagingParams({
       page: (pagination.current || 1) - 1,
       size: pagination.pageSize || 10,
-      sortBy: isSorted ? (singleSorter.field as string) : undefined,
+      sortBy: isSorted ? ("ratingScore") : undefined,
       sortDirection: mapSortDirection(singleSorter),
     });
   };
@@ -138,6 +137,14 @@ const CaretakerList = () => {
       ...prevParams,
       page: 0, // Reset to first page on search
     }));
+  };
+
+  const handleSortChange = (sortBy: string, sortDirection: string) => {
+    setPagingParams({
+      ...pagingParams,
+      sortBy: sortBy,
+      sortDirection: sortDirection,
+    });
   };
 
   const updateAnimalFilters = (
@@ -196,10 +203,7 @@ const CaretakerList = () => {
       render: (_: unknown, record: CaretakerBasics) => (
         <div className="caretaker-list-item">
           <div className="profile-picture">
-            {record.accountData.profilePicture 
-              ? <img src={record.accountData.profilePicture.url} alt="avatar" />
-              : <UserOutlined style={{ fontSize: "150px" }} />
-            }
+            <img src={record.accountData.profilePicture?.url || "/default-avatar.png"} alt="avatar" />
           </div>
           <div>
             <h4>
@@ -225,7 +229,6 @@ const CaretakerList = () => {
       title: t("rating"),
       dataIndex: "avgRating",
       key: "avgRating",
-      sorter: true,
       render: (rating: number | null, record: CaretakerBasics) => (
         <div className="caretaker-rating">
           {rating ? (
@@ -251,25 +254,23 @@ const CaretakerList = () => {
 
   return (
     <div className="caretaker-container">
-      <Spin spinning={isLoading} fullscreen />
       <CaretakerFilters
         filters={filters}
         animalFilters={animalFilters}
         onFiltersChange={setFilters}
         onAnimalFiltersChange={updateAnimalFilters}
         onAnimalTypesChange={handleAnimalTypesChange}
+        onSortChange={handleSortChange}
         onSearch={handleSearch}
       />
       <Tabs style={{width: "100%"}} centered size="small">
         <TabPane tab={t("caretakerSearch.list")} key="list">
           <div className="caretaker-content">
             <Table
+              loading={isLoading}
               columns={columns}
               locale={{
                 emptyText: t("caretakerSearch.noCaretakers"),
-                triggerDesc: t("triggerDesc"),
-                triggerAsc: t("triggerAsc"),
-                cancelSort: t("cancelSort"),
               }}
               dataSource={caretakers}
               rowKey={(record) => record.accountData.email}

--- a/src/scss/pages/_caretakerSearch.scss
+++ b/src/scss/pages/_caretakerSearch.scss
@@ -107,6 +107,7 @@
         width: 100%;
         height: 100%;
         border-radius: 50%;
+        border: 3px solid v.$blue-dark;
       }
     }
 


### PR DESCRIPTION
## Opis
Po dodaniu `ratingScore` na backendzie, umożliwiłem sortowanie po tym wskaźniku przy wyszukiwaniu opiekunów.   
  
Na dodatek dałem możliwość sortowania również po innych polach. W związku z tym usunąłem sortowanie po kliknięciu w nagłówek kolumny z oceną. Zamiast tego w pasku bocznym, w którym mamy filtry, jest teraz też możliwość sortowania po wybranej opcji z Select'a:  
![image](https://github.com/user-attachments/assets/c17f3496-ed2a-4eee-9410-7a9eea452036)
![image](https://github.com/user-attachments/assets/df4c12b5-453b-4e6b-bde2-804149560dc8)
