### PR TITLE
FE-47, Wyświetlenie zdjęć opiekuna na jego profilu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -307,5 +307,6 @@
     "newNotification": "You have a new notification"
   },
 
-  "termsAndConditions": "Terms and conditions"
+  "termsAndConditions": "Terms and conditions",
+  "clickToZoom": "Click to zoom"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -118,6 +118,7 @@
   "description": "Description",
   "upload": "Upload",
   "offerPhotos": "Offer photos",
+  "caretakerForm": "Caretaker form",
   "currentPhotos": "Current photos",
   "newPhotos": "New photos",
   "photosLimitMessage": "Photos limit",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -296,6 +296,7 @@
   "youWillLose": "You will lose",
 
   "noAvailability": "Caretaker did not set the availability",
+  "needToLoginAsClient": "You need to log in as client to be able to request care",
 
   "notification": {
     "title": "Notifications",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -315,5 +315,6 @@
     "newNotification": "Masz nowe powiadomienie"
   },
 
-  "termsAndConditions": "Polityka prywatności"
+  "termsAndConditions": "Polityka prywatności",
+  "clickToZoom": "Naciśnij aby powiekszyć"
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -304,6 +304,7 @@
   "youWillLose": "Stracisz",
 
   "noAvailability": "Opiekun nie ustawił dostępności",
+  "needToLoginAsClient": "Musisz być zalogowany jako klient, aby dokonać rezerwacji opieki",
 
   "notification": {
     "title": "Powiadomienia",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -124,6 +124,7 @@
   "description": "Opis",
   "upload": "Prześlij",
   "offerPhotos": "Zdjęcia oferty",
+  "caretakerForm": "Formularz opiekuna",
   "currentPhotos": "Aktualne zdjęcia",
   "newPhotos": "Nowe zdjęcia",
   "photosLimitMessage": "Limit zdjęć",

--- a/src/components/Offer/OfferConfigurations.tsx
+++ b/src/components/Offer/OfferConfigurations.tsx
@@ -167,6 +167,16 @@ const OfferConfigurations: React.FC<ConfigurationsProps> = ({
     setEditingKey(undefined);
   };
 
+  const getTooltipText = () => {
+    if (availabilities.length === 0) {
+      return t("noAvailability");
+    } else if (store.user.profile?.selected_profile !== "CLIENT") {
+      return t("needToLoginAsClient");
+    } else {
+      return undefined;
+    }
+  };
+
   const selectedOptionsColumns: ColumnType<OfferConfigurationWithOptionalId>[] =
     store.animal.getAnimalAttributeKeys(animalType).map((attributeKey) => ({
       title: t(attributeKey.toLowerCase()),
@@ -245,7 +255,6 @@ const OfferConfigurations: React.FC<ConfigurationsProps> = ({
       onCell: () => ({
         style: { minWidth: 150, maxWidth: 200 },
       }),
-      hidden: !canBeEdited && store.user.profile?.selected_profile !== "CLIENT",
       render: (record: OfferConfigurationWithOptionalId) => {
         const editable = isEditing(record);
         return canBeEdited ? (
@@ -293,7 +302,7 @@ const OfferConfigurations: React.FC<ConfigurationsProps> = ({
             </Space>
           )
         ) : (
-          <Tooltip title={availabilities.length === 0 && t("noAvailability")}>
+          <Tooltip title={getTooltipText()}>
             <Button
               type="primary"
               onClick={() => navigate(
@@ -308,7 +317,7 @@ const OfferConfigurations: React.FC<ConfigurationsProps> = ({
                 }
               )}
               loading={isLoading}
-              disabled={availabilities.length === 0}
+              disabled={availabilities.length === 0 || store.user.profile?.selected_profile !== "CLIENT"}
             >
               {t("sendRequest")}
             </Button>

--- a/src/pages/CaretakerForm.tsx
+++ b/src/pages/CaretakerForm.tsx
@@ -174,182 +174,190 @@ const CaretakerForm = () => {
   };
 
   return (
-    <div className="caretaker-form-container">
-      <Spin size="large" spinning={isStarting}>
-        <Form form={form} layout="vertical" onFinish={handleSubmit} scrollToFirstError>
-          <Space direction="vertical" size="large" style={{ width: "100%" }}>
-            <Card title={t("address")}>
-              <div className="card-grid-row">
-                <Form.Item
-                  label={t("addressDetails.street")}
-                  name={["address", "street"]}
-                  rules={[
-                    { required: true, message: t("validation.required") },
-                  ]}
-                >
-                  <Input
-                    maxLength={150}
-                    placeholder={t("placeholder.street")}
-                  />
-                </Form.Item>
-                <Form.Item
-                  label={t("addressDetails.streetNumber")}
-                  name={["address", "streetNumber"]}
-                  rules={[
-                    { required: true, message: t("validation.required") },
-                  ]}
-                >
-                  <Input
-                    maxLength={10}
-                    placeholder={t("placeholder.streetNumber")}
-                  />
-                </Form.Item>
-                <Form.Item
-                  label={t("addressDetails.apartmentNumber")}
-                  name={["address", "apartmentNumber"]}
-                >
-                  <Input
-                    maxLength={10}
-                    placeholder={t("placeholder.apartmentNumber")}
-                  />
-                </Form.Item>
-              </div>
+    <div className="caretaker-form-wrapper">
+      <h1>{t("caretakerForm")}</h1>
+      <div className="caretaker-form-container">
+        <Spin size="large" spinning={isStarting}>
+          <Form
+            form={form}
+            layout="vertical"
+            onFinish={handleSubmit}
+            scrollToFirstError
+          >
+            <Space direction="vertical" size="large" style={{ width: "100%" }}>
+              <Card title={t("address")}>
+                <div className="card-grid">
+                  <Form.Item
+                    label={t("addressDetails.street")}
+                    name={["address", "street"]}
+                    rules={[
+                      { required: true, message: t("validation.required") },
+                    ]}
+                  >
+                    <Input
+                      maxLength={150}
+                      placeholder={t("placeholder.street")}
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("addressDetails.streetNumber")}
+                    name={["address", "streetNumber"]}
+                    rules={[
+                      { required: true, message: t("validation.required") },
+                    ]}
+                  >
+                    <Input
+                      maxLength={10}
+                      placeholder={t("placeholder.streetNumber")}
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("addressDetails.apartmentNumber")}
+                    name={["address", "apartmentNumber"]}
+                  >
+                    <Input
+                      maxLength={10}
+                      placeholder={t("placeholder.apartmentNumber")}
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("addressDetails.zipCode")}
+                    name={["address", "zipCode"]}
+                    rules={[
+                      { required: true, message: t("validation.required") },
+                      {
+                        pattern: /^[0-9]{2}-[0-9]{3}$/,
+                        message: t("validation.zipCodeFormat"),
+                      },
+                    ]}
+                  >
+                    <Input
+                      maxLength={6}
+                      onKeyDown={handleZipCodeKeyDown}
+                      placeholder={t("placeholder.zipCode")}
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("addressDetails.city")}
+                    name={["address", "city"]}
+                    rules={[
+                      { required: true, message: t("validation.required") },
+                    ]}
+                  >
+                    <Input maxLength={50} placeholder={t("placeholder.city")} />
+                  </Form.Item>
+                  <Form.Item
+                    label={t("addressDetails.voivodeship")}
+                    name={["address", "voivodeship"]}
+                    rules={[
+                      { required: true, message: t("validation.required") },
+                    ]}
+                  >
+                    <Select placeholder={t("placeholder.voivodeship")}>
+                      {renderSelectOptions(Voivodeship.voivodeshipMap)}
+                    </Select>
+                  </Form.Item>
+                </div>
+              </Card>
 
-              <div className="card-grid-row">
+              <Card title={t("personalData.contactDetails")}>
                 <Form.Item
-                  label={t("addressDetails.zipCode")}
-                  name={["address", "zipCode"]}
+                  label={t("personalData.phoneNumber")}
+                  name="phoneNumber"
                   rules={[
                     { required: true, message: t("validation.required") },
                     {
-                      pattern: /^[0-9]{2}-[0-9]{3}$/,
-                      message: t("validation.zipCodeFormat"),
+                      pattern: /^([0-9]){9,14}$/,
+                      message: t("validation.phoneNumberFormat"),
                     },
                   ]}
+                  style={{ width: "200px" }}
                 >
                   <Input
-                    maxLength={6}
-                    onKeyDown={handleZipCodeKeyDown}
-                    placeholder={t("placeholder.zipCode")}
+                    maxLength={14}
+                    placeholder={t("placeholder.phoneNumber")}
+                    onKeyDown={handleKeyDownForNumeric}
+                    addonBefore="+48"
                   />
                 </Form.Item>
-                <Form.Item
-                  label={t("addressDetails.city")}
-                  name={["address", "city"]}
-                  rules={[
-                    { required: true, message: t("validation.required") },
-                  ]}
-                >
-                  <Input maxLength={50} placeholder={t("placeholder.city")} />
-                </Form.Item>
-                <Form.Item
-                  label={t("addressDetails.voivodeship")}
-                  name={["address", "voivodeship"]}
-                  rules={[
-                    { required: true, message: t("validation.required") },
-                  ]}
-                >
-                  <Select placeholder={t("placeholder.voivodeship")}>
-                    {renderSelectOptions(Voivodeship.voivodeshipMap)}
-                  </Select>
-                </Form.Item>
-              </div>
-            </Card>
+              </Card>
 
-            <Card title={t("personalData.contactDetails")}>
-              <Form.Item
-                label={t("personalData.phoneNumber")}
-                name="phoneNumber"
-                rules={[
-                  { required: true, message: t("validation.required") },
-                  {
-                    pattern: /^([0-9]){9,14}$/,
-                    message: t("validation.phoneNumberFormat"),
-                  },
-                ]}
-                style={{ width: "200px" }}
-              >
-                <Input
-                  maxLength={14}
-                  placeholder={t("placeholder.phoneNumber")}
-                  onKeyDown={handleKeyDownForNumeric}
-                  addonBefore="+48"
-                />
-              </Form.Item>
-            </Card>
-
-            <Card title={t("description")}>
-              <Form.Item name="description">
-                <Input.TextArea
-                  showCount
-                  autoSize={{ minRows: 2, maxRows: 4 }}
-                  maxLength={1500}
-                  placeholder={t("placeholder.description")}
-                />
-              </Form.Item>
-            </Card>
-
-            <Card title={t("offerPhotos")}>
-              <Skeleton loading={isPhotosLoading} paragraph={{ rows: 2 }}>
-                <Form.Item
-                  name="offerPhotos"
-                  label={t("currentPhotos")}
-                  hidden={currentOfferPhotos.length === 0}
-                >
-                  <Upload
-                    listType="picture-card"
-                    fileList={currentOfferPhotos.map((photo) => photo.file)}
-                    onRemove={handleRemoveCurrentPhoto}
-                    onPreview={handleFilePreview}
+              <Card title={t("description")}>
+                <Form.Item name="description">
+                  <Input.TextArea
+                    showCount
+                    autoSize={{ minRows: 2, maxRows: 4 }}
+                    maxLength={1500}
+                    placeholder={t("placeholder.description")}
                   />
                 </Form.Item>
-              </Skeleton>
-              <Form.Item
-                name="newOfferPhotos"
-                label={t("newPhotos")}
-                hidden={currentOfferPhotos.length >= PHOTOS_LIMIT}
-              >
-                <ImgCrop
-                  beforeCrop={hasFilePhotoType}
-                  rotationSlider
-                  modalTitle={t("imageCropperTitle")}
-                  modalOk={t("apply")}
-                  modalCancel={t("cancel")}
-                >
-                  <Upload
-                    customRequest={dummyRequest}
-                    listType="picture-card"
-                    fileList={newOfferPhotos}
-                    onChange={handleNewPhoto}
-                    onPreview={handleFilePreview}
-                    accept="image/*"
+              </Card>
+
+              <Card title={t("offerPhotos")}>
+                <Skeleton loading={isPhotosLoading} paragraph={{ rows: 2 }}>
+                  <Form.Item
+                    name="offerPhotos"
+                    label={t("currentPhotos")}
+                    hidden={currentOfferPhotos.length === 0}
                   >
-                    {currentOfferPhotos.length + newOfferPhotos.length <
-                      PHOTOS_LIMIT && `+ ${t("upload")}`}
-                  </Upload>
-                </ImgCrop>
-              </Form.Item>
-              {currentOfferPhotos.length + newOfferPhotos.length >=
-                PHOTOS_LIMIT && (
-                <Alert
-                  type="warning"
-                  showIcon
-                  message={t("photosLimitMessage")}
-                  description={t("photosLimitDescription")}
-                />
-              )}
-            </Card>
-            <Button
-              type="primary"
-              htmlType="submit"
-              className="submit-button"
-              loading={isLoading}
-            >
-              {t("save")}
-            </Button>
-          </Space>
-        </Form>
-      </Spin>
+                    <Upload
+                      listType="picture-card"
+                      fileList={currentOfferPhotos.map((photo) => photo.file)}
+                      onRemove={handleRemoveCurrentPhoto}
+                      onPreview={handleFilePreview}
+                    />
+                  </Form.Item>
+                </Skeleton>
+                <Form.Item
+                  name="newOfferPhotos"
+                  label={t("newPhotos")}
+                  hidden={currentOfferPhotos.length >= PHOTOS_LIMIT}
+                >
+                  <ImgCrop
+                    beforeCrop={hasFilePhotoType}
+                    rotationSlider
+                    modalTitle={t("imageCropperTitle")}
+                    modalOk={t("apply")}
+                    modalCancel={t("cancel")}
+                  >
+                    <Upload
+                      customRequest={dummyRequest}
+                      listType="picture-card"
+                      fileList={newOfferPhotos}
+                      onChange={handleNewPhoto}
+                      onPreview={handleFilePreview}
+                      accept="image/*"
+                    >
+                      {currentOfferPhotos.length + newOfferPhotos.length <
+                        PHOTOS_LIMIT && `+ ${t("upload")}`}
+                    </Upload>
+                  </ImgCrop>
+                </Form.Item>
+                {currentOfferPhotos.length + newOfferPhotos.length >=
+                  PHOTOS_LIMIT && (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    message={t("photosLimitMessage")}
+                    description={t("photosLimitDescription")}
+                  />
+                )}
+              </Card>
+              <Space style={{ float: "right" }}>
+                <Button onClick={() => navigate(-1)}>{t("cancel")}</Button>
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  className="submit-button"
+                  loading={isLoading}
+                >
+                  {t("save")}
+                </Button>
+              </Space>
+            </Space>
+          </Form>
+        </Spin>
+      </div>
     </div>
   );
 };

--- a/src/pages/CaretakerProfile.tsx
+++ b/src/pages/CaretakerProfile.tsx
@@ -7,6 +7,7 @@ import {
   Rate,
   Upload,
   Avatar,
+  Image,
 } from "antd";
 import { PictureOutlined, UserOutlined } from "@ant-design/icons";
 import CommentContainer from "../components/CommentContainer";
@@ -121,6 +122,21 @@ const CaretakerProfile: React.FC = () => {
                     className="profile-image"
                     icon={<UserOutlined />}
                   />
+                )}
+                {profileData.offerPhotos && profileData.offerPhotos.length > 0 && (
+                  <div className="background-images">
+                    <Image.PreviewGroup>
+                      {profileData.offerPhotos.map((photo, index) => (
+                        <Image
+                          key={index}
+                          src={photo.url}
+                          preview={{
+                            mask: <span>{t("clickToZoom")}</span>,
+                          }}
+                        />
+                      ))}
+                    </Image.PreviewGroup>
+                  </div>
                 )}
               </div>
               {isMyProfile === true && (

--- a/src/scss/pages/_caretakerForm.scss
+++ b/src/scss/pages/_caretakerForm.scss
@@ -1,25 +1,52 @@
 @use "../helpers/variables" as v;
 
-.caretaker-form-container {
-  max-width: 800px;
-  margin: 5vh auto;
-  padding: 20px;
-  background-color: v.$white;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
 
-.card-grid-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 50px;
-}
+.caretaker-form-wrapper {
+  margin: 3vh auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 
-.ant-card {
-  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.1);
-
-  .ant-card-head {
-    background: v.$blue-dark;
-    color: v.$white
+  h1 {
+    color: v.$white;
   }
+
+  .caretaker-form-container {
+    max-width: 800px;
+    width: 90%;
+    padding: 20px;
+    background-color: v.$white;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+
+    @media (max-width: 768px) {
+      width: 95%;
+    }
+  }
+  
+  .card-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 30px;
+
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;  
+    }
+
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+      gap: 20px;  
+    }
+  }
+  
+  .ant-card {
+    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.1);
+  
+    .ant-card-head {
+      background: v.$blue-dark;
+      color: v.$white
+    }
+  }  
 }

--- a/src/scss/pages/_profile.scss
+++ b/src/scss/pages/_profile.scss
@@ -46,11 +46,12 @@
           position: absolute;
           width: 100%;
           height: 100%;
-          display: flex;
+          display: grid;
+          grid-template-columns: 1fr 1fr;
           gap: 2px;
           z-index: 0;
           overflow: hidden;
-          opacity: 0.8;
+          opacity: 0.9;
           border-radius: 8px;
 
           .ant-image {

--- a/src/scss/pages/_profile.scss
+++ b/src/scss/pages/_profile.scss
@@ -26,15 +26,38 @@
       //   flex-direction: column;
       // }
       .profile-picture-container {
+        position: relative; /* Dla kontrolowania z-index */
+        padding: 40px 20px;
         width: 100%;
         display: flex;
         justify-content: center;
+        align-items: center;
+
         .profile-image {
+          z-index: 1;
           border-radius: 50%; /* przycinanie do kształtu koła */
           object-fit: cover;
           border: 4px solid v.$blue-dark;
           width: 250px;
           height: 250px;
+        }
+
+        .background-images {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          display: flex;
+          gap: 2px;
+          z-index: 0;
+          overflow: hidden;
+          opacity: 0.8;
+          border-radius: 8px;
+
+          .ant-image {
+            height: 100%;
+            width: auto !important;
+            aspect-ratio: 1 / 1;
+          }
         }
       }
 

--- a/src/scss/pages/_profile.scss
+++ b/src/scss/pages/_profile.scss
@@ -26,7 +26,7 @@
       //   flex-direction: column;
       // }
       .profile-picture-container {
-        position: relative; /* Dla kontrolowania z-index */
+        position: relative;
         padding: 40px 20px;
         width: 100%;
         display: flex;
@@ -37,6 +37,7 @@
           z-index: 1;
           border-radius: 50%; /* przycinanie do kształtu koła */
           object-fit: cover;
+          background-color: v.$grey-light;
           border: 4px solid v.$blue-dark;
           width: 250px;
           height: 250px;

--- a/src/scss/pages/_profileSelection.scss
+++ b/src/scss/pages/_profileSelection.scss
@@ -16,11 +16,13 @@
   .selection-nested-container {
     display: flex;
     justify-content: center;
+    padding: 10px;
     gap: 10vw;
     width: 100%;
+
     .profile-container {
       width: 50%;
-      min-width: 100px;
+      min-width: 80px;
       max-width: 180px;
       aspect-ratio: 1 / 1;
       height: 100%;
@@ -28,7 +30,7 @@
       flex-direction: column;
       justify-content: space-between;
       align-items: center;
-      //TODO: fix bad scaling when width is small (box is not square anymore)
+
       .profile-box {
         width: 100%;
         color: v.$blue-medium;

--- a/src/scss/pages/_profileSelection.scss
+++ b/src/scss/pages/_profileSelection.scss
@@ -19,7 +19,10 @@
     gap: 10vw;
     width: 100%;
     .profile-container {
-      width: 10%;
+      width: 50%;
+      min-width: 100px;
+      max-width: 180px;
+      aspect-ratio: 1 / 1;
       height: 100%;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## Opis
Dodałem te zdjęcia w tle zdjęcia profilowego. Wyświetlane są dwa pierwsze lub cztery, zależy od rozdzielczości. 
  
Przykładowo tak to wygląda na komputerze:  
![image](https://github.com/user-attachments/assets/9e1d87f8-0689-495d-82e6-317aecde7730)

A tak na telefonie:
![image](https://github.com/user-attachments/assets/ad871d82-495a-4daf-a212-8a3d52b544ef)

Po najechaniu kursorem na zdjęcie, widać, że jest klikalne:  
![image](https://github.com/user-attachments/assets/5d52064b-81e6-45df-a3a3-39cae84cfdcb)

Po kliknięciu możemy przeglądać wszystkie zdjęcia opiekuna:  
![image](https://github.com/user-attachments/assets/6f969467-1126-4acc-a074-ae1b39dd8216)

I jeszcze dodatkowo małe poprawki:

1. Dodałem przycisk anuluj przy formularzu opiekuna (cofa do poprzedniej strony):  
![image](https://github.com/user-attachments/assets/43b1257a-349a-4940-ba8b-8d4512a78a3d)

2. Poprawiłem responsywność ekranu do wyboru profilu, przykład na telefonie, width: 383px  
![image](https://github.com/user-attachments/assets/cbacf7ef-a6df-43c4-ba5b-7547c963603e)
